### PR TITLE
Knock out a batch of issues (#8 #23 #24 #35 #36 #37 #39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,30 @@
 # pervellam
 
+## install
+
+1. Clone this repo and `cd` into it.
+2. Install the dependencies (server + worker):
+
+   ```
+   pip install -U "yt-dlp[default]" "fastapi[standard]" \
+     https://github.com/ctengel/objectindex/archive/refs/tags/v0.3.5.tar.gz \
+     https://github.com/ctengel/simpler-objects/archive/refs/tags/v0.4.6.tar.gz
+   ```
+
+   `fastapi[standard]` pulls in what the server needs (FastAPI, uvicorn,
+   SQLAlchemy, pydantic); `objectindex` / `simpler-objects` are used by the
+   worker to upload to ObjectIndex; `yt-dlp` does the actual downloading.
+3. Create your config from the template and edit it:
+
+   ```
+   cp config.samp.py config.py
+   ```
+4. Run the server (see below). The server listens on port **29206**.
+
 ## server
 
 ```
-fastapi run --port 29206
+fastapi run --port 29206 server.py
 ```
 
 or for development:
@@ -17,6 +38,30 @@ fastapi dev --port 29206 --host 0.0.0.0 server.py
 A worker runs `worker.py` to pull jobs from a Pervellam server and download them
 with [yt-dlp](https://github.com/yt-dlp/yt-dlp). `worker-loop.sh` wraps it in a
 loop so a node keeps picking up new jobs.
+
+### Running a worker
+
+The worker uploads finished downloads to ObjectIndex, so it needs `OBJIDX_URL`
+and `OBJIDX_AUTH` set in its environment. Point it at the server's port (29206).
+
+One shot (picks up at most one job, then exits):
+
+```
+OBJIDX_URL=... OBJIDX_AUTH=... ./worker.py <server> <worker-id> <datadir> <bucket>
+```
+
+- `<server>` — Pervellam server URL, e.g. `http://localhost:29206/`
+- `<worker-id>` — a name unique to this worker (recorded as the job's `dler`)
+- `<datadir>` — temp dir for downloads; the worker creates a `<worker-id>-<job-id>`
+  subdir under it per job
+- `<bucket>` — ObjectIndex bucket to upload into
+
+Keep picking up jobs in a loop (`worker-loop.sh` sleeps `<interval>` seconds
+between runs):
+
+```
+OBJIDX_URL=... OBJIDX_AUTH=... ./worker-loop.sh <server> <interval> <worker-id> <datadir> <bucket>
+```
 
 ### Keeping yt-dlp up to date
 

--- a/server.py
+++ b/server.py
@@ -5,7 +5,7 @@ from typing import Union  # Annotated
 from fastapi import FastAPI, Depends, HTTPException
 from fastapi.staticfiles import StaticFiles
 #from fastapi.security import HTTPBasic, HTTPBasicCredentials
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from sqlalchemy import create_engine, Column, String, Integer, DateTime
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, Session
@@ -30,11 +30,10 @@ class Job(BaseModel):
     dler: Union[str, None] = None
     fname: Union[str, None] = None
     status: Union[str, None] = None
+    size: Union[int, None] = None
     started: Union[datetime.datetime, None] = None
     updated: Union[datetime.datetime, None] = None
-    class Config:
-        """Needed for fastapi<->sqlalchemy?"""
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)  # needed for fastapi<->sqlalchemy
 
 class Dler(BaseModel):
     """Simple model temporarily for assign"""
@@ -75,6 +74,7 @@ class JobTable(Base):
     dler = Column(String(16))
     fname = Column(String(64))
     status = Column(String(8), default='new')
+    size = Column(Integer)
     started = Column(DateTime)
     updated = Column(DateTime)
 
@@ -88,6 +88,12 @@ def joblist(filt: str = None, db: Session = Depends(get_db)) -> list[Job]:
         return db.query(JobTable).filter(JobTable.status == 'new').all()
     if filt == 'active':
         return db.query(JobTable).filter(~JobTable.status.in_(['ended', 'stopped'])).all()
+    if filt == 'finished':
+        return (db.query(JobTable)
+                .filter(JobTable.status.in_(['ended', 'stopped']))
+                .order_by(JobTable.updated.desc())
+                .limit(20)
+                .all())
     return db.query(JobTable).all()
 
 @app.get('/jobs/{job_id}')

--- a/static/index.html
+++ b/static/index.html
@@ -81,6 +81,19 @@ while (tableContainer.firstChild) {
 	subx.value = stuck ? 'Force' : 'Stop';
 	formx.appendChild(subx);
 	tdx.appendChild(formx);
+	// Pause = stop the current job and re-queue the same URL at the bottom (#24).
+	if (!stuck) {
+		var formp = document.createElement('form');
+		var subp = document.createElement('input');
+		formp.onsubmit = function (event) {
+			event.preventDefault();
+			pauseJob(obj['id'], obj['url']);
+		}
+		subp.type = 'submit';
+		subp.value = 'Pause';
+		formp.appendChild(subp);
+		tdx.appendChild(formp);
+	}
 	row.appendChild(tdx);
         tbody.appendChild(row);
       });
@@ -171,6 +184,7 @@ fetch('/jobs/?filt=active', {
   console.log(data);
   // Process the data or update the UI here
   generateTable(data)
+  getFinishedData()
 })
 .catch(function(error) {
   console.log('Error:', error.message);
@@ -223,10 +237,83 @@ fetch('/jobs/?filt=active', {
         // Handle network error here
       });
     }
+   // Pause a job: stop it, then re-queue the same URL as a fresh job (#24).
+   function pauseJob(job_id, url) {
+      fetch('/jobs/' + job_id + '/stop', { method: 'POST' })
+      .then(function() { return createJob(url); })
+      .then(function() { getApiData(); })
+      .catch(function(error) { console.log('Error:', error); });
+    }
+    // Build the "Recently finished" table, linking finished jobs to ObjectIndex (#23).
+    function generateFinishedTable(jsonResponse) {
+      var container = document.getElementById('finishedContainer');
+      while (container.firstChild) {
+        container.removeChild(container.firstChild);
+      }
+      if (!jsonResponse.length) {
+        return;
+      }
+      var heading = document.createElement('h3');
+      heading.textContent = 'Recently finished';
+      container.appendChild(heading);
+      var table = document.createElement('table');
+      var thead = document.createElement('thead');
+      var headerRow = document.createElement('tr');
+      ['url', 'status', 'OI'].forEach(function (label) {
+        var th = document.createElement('th');
+        th.textContent = label;
+        headerRow.appendChild(th);
+      });
+      thead.appendChild(headerRow);
+      table.appendChild(thead);
+      var tbody = document.createElement('tbody');
+      jsonResponse.forEach(function (obj) {
+        var row = document.createElement('tr');
+        var tdu = document.createElement('td');
+        var urla = document.createElement('a');
+        urla.href = obj['url'];
+        urla.textContent = obj['url'].substring(obj['url'].lastIndexOf('/') + 1);
+        tdu.appendChild(urla);
+        row.appendChild(tdu);
+        var tds = document.createElement('td');
+        tds.textContent = obj['status'];
+        row.appendChild(tds);
+        var tdo = document.createElement('td');
+        if (obj['fname']) {
+          var oia = document.createElement('a');
+          oia.href = obj['fname'];
+          oia.textContent = 'Open in OI';
+          tdo.appendChild(oia);
+        }
+        row.appendChild(tdo);
+        tbody.appendChild(row);
+      });
+      table.appendChild(tbody);
+      container.appendChild(table);
+    }
+    function getFinishedData() {
+      fetch('/jobs/?filt=finished', {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' }
+      })
+      .then(function(response) {
+        if (response.ok) {
+          return response.json();
+        }
+        throw new Error('Error: ' + response.status);
+      })
+      .then(function(data) {
+        generateFinishedTable(data);
+      })
+      .catch(function(error) {
+        console.log('Error:', error.message);
+      });
+    }
   </script>
 </head>
 <body onload="getApiData();setupBookmarklet();checkAutoSubmit()">
   <div id="tableContainer"></div>
+  <div id="finishedContainer"></div>
   <div>
   <form id="postForm" onsubmit="postData(event)">
     <label for="url">URL:</label>

--- a/static/index.html
+++ b/static/index.html
@@ -19,6 +19,10 @@
     }
   </style>
   <script>
+    // Drop sub-second precision from an ISO timestamp for display (#23 follow-up).
+    function truncateToSecond(value) {
+      return value ? String(value).replace(/\.\d+/, '') : value;
+    }
     // Generate HTML table from JSON response
     function generateTable(jsonResponse) {
       var tableContainer = document.getElementById('tableContainer');
@@ -59,6 +63,8 @@ while (tableContainer.firstChild) {
 		  urla.href = obj['url']
 		  urla.textContent = obj['url'].substring(obj['url'].lastIndexOf('/') + 1);
 		  td.appendChild(urla);
+          } else if (prop == 'started' || prop == 'updated') {
+          	td.textContent = truncateToSecond(obj[prop]);
           } else {
           	td.textContent = obj[prop];
 	  }
@@ -244,6 +250,20 @@ fetch('/jobs/?filt=active', {
       .then(function() { getApiData(); })
       .catch(function(error) { console.log('Error:', error); });
     }
+    // Resolve a finished job's OI file URL to its real (presigned) download and go there (#23).
+    function openInOi(fileUrl) {
+      fetch(fileUrl, { headers: { 'Accept': 'application/json' } })
+      .then(function (r) { return r.json(); })
+      .then(function (file) {
+        var objId = file.file_object.uuid;
+        // fname is "<base>file/<uuid>"; build "<base>object/<objId>/download".
+        var base = fileUrl.replace(/file\/[^/]+\/?$/, '');
+        return fetch(base + 'object/' + objId + '/download');
+      })
+      .then(function (r) { return r.json(); })
+      .then(function (dl) { window.location = dl.presigned; })
+      .catch(function (error) { console.log('Error:', error); });
+    }
     // Build the "Recently finished" table, linking finished jobs to ObjectIndex (#23).
     function generateFinishedTable(jsonResponse) {
       var container = document.getElementById('finishedContainer');
@@ -281,8 +301,10 @@ fetch('/jobs/?filt=active', {
         var tdo = document.createElement('td');
         if (obj['fname']) {
           var oia = document.createElement('a');
-          oia.href = obj['fname'];
+          oia.href = '#';
           oia.textContent = 'Open in OI';
+          var fname = obj['fname'];
+          oia.onclick = function (event) { event.preventDefault(); openInOi(fname); };
           tdo.appendChild(oia);
         }
         row.appendChild(tdo);

--- a/worker.py
+++ b/worker.py
@@ -94,7 +94,9 @@ def run_one(dler, myj):
             #      because since this download is still healthy better to stay in normal loop
             warnings.warn('Cannot get status from Pervellam server, will retry in a minute...')
             continue
-        if pjs == "stopreq":
+        # 'stopped' here means a force-stop already flipped the status (issue #39);
+        # treat it like a stopreq so the still-running download is actually killed.
+        if pjs in ("stopreq", "stopped"):
             print('Recieved stop request...')
             myd.stop()
             print('Job stopped!')


### PR DESCRIPTION
Clears a batch of open issues in one pass.

| Issue | Change |
|---|---|
| #37 | Silence pydantic V2 deprecation warning (`orm_mode` → `from_attributes` via `ConfigDict`) |
| #39 | Worker treats a force-stop `stopped` status like `stopreq`, so a still-running download is actually killed instead of running forever |
| #8 | Add job `size` field (column + model); worker already reports it, and it auto-shows in the webgui |
| #23 | New `?filt=finished` server filter + a "Recently finished" webgui table linking each job to ObjectIndex via `fname` |
| #24 | New **Pause** button: stops a job and re-queues its URL at the bottom of the queue |
| #36 | Install guide added to README (clone, deps, config, run) |
| #35 | Document `worker.py` / `worker-loop.sh` invocation, `OBJIDX_*` env vars, and port 29206 |

Omitted from the requested batch: #7 (vague validation), #31 (vague channel export), #9 (deferred).

## Verification
- `python -c "import server"` imports with no pydantic `orm_mode` warning.
- TestClient run: POST job, PATCH `size` → stored & returned; `?filt=finished` returns the ended job (with `fname`/`size`) and `?filt=active` excludes it.
- Worker (#39) and webgui (#23/#24) changes reviewed by read-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)