### PR TITLE
ML-guessed stream ratings (issue #21)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,5 +134,8 @@ sql_app.db
 # silly config file
 config.py
 
+# ML snapshots, scores and trained model (prioritize.py level 3)
+ml_data/
+
 # vim swapfile
 *.swp

--- a/README.md
+++ b/README.md
@@ -94,3 +94,38 @@ Needs in `config.py`:
   for the `streams/followed` scope (a localhost OAuth redirect works for the
   one-time user authorization). See `config.samp.py` for the full list and
   [OAUTH.md](OAUTH.md) for detailed instructions on how to obtain.
+
+### Level 3 — ML (`-m`)
+
+```
+./prioritize.py <server> --ml
+```
+
+Instead of a human-written priority file, this ranks the live followed streams
+with a model trained on **your own ratings** of past streams, then keeps the top
+`MAX` running (same add/stop reconciliation as level 2). Use `--dry-run` to print
+the ranked add/stop plan without touching the server.
+
+This adapts the [antialgorithm](https://github.com/ctengel/antialgorithm) RSS
+experiment to streams. The pipeline:
+
+```
+./stream_snap.py     # snapshot live followed streams -> ml_data/snapshots/*.json
+./stream_score.py    # rate snapshots a/b/c/d/f       -> ml_data/scores.csv
+./stream_train.py    # train + report accuracy        -> ml_data/model.joblib
+./prioritize.py <server> --ml --dry-run   # see what it would record
+```
+
+Run `stream_snap.py` on a timer to accumulate a corpus, rate a few dozen with
+`stream_score.py`, then `stream_train.py`. Re-run snap/score/train periodically
+to keep the model fresh.
+
+Extra requirements (`pip install -r requirements.txt`): `scikit-learn`, `nltk`,
+`joblib`. One-time NLTK data download:
+
+```
+python -c "import nltk; nltk.download('stopwords'); nltk.download('punkt'); nltk.download('punkt_tab')"
+```
+
+Needs in `config.py`: everything from level 2 plus `ML_DATA` and `ML_MODEL`
+(see `config.samp.py`).

--- a/config.samp.py
+++ b/config.samp.py
@@ -4,8 +4,12 @@
 MYDLP = '/usr/bin/yt-dlp'
 BASE_URL = 'https://www.website.com/'
 
-# prioritize.py level 2 (prioritized) only
+# prioritize.py level 2 (prioritized) and level 3 (ML) only
 MAX = 5  # max concurrent jobs to keep running
+
+# prioritize.py level 3 (ML) and the stream_* tooling
+ML_DATA = './ml_data'                    # snapshots/ and scores.csv live here
+ML_MODEL = './ml_data/model.joblib'      # trained model saved/loaded here
 
 # OAuth (prioritize.py level 2 only)
 TW_URL = 'https://api.website.com/helix/'   # Helix API base

--- a/prioritize.py
+++ b/prioritize.py
@@ -7,6 +7,7 @@ import random
 import tw
 import pervellam_client
 import config
+import stream_ml
 
 def read_prifile(prifile):
     """Read a simple priorities file"""
@@ -14,15 +15,12 @@ def read_prifile(prifile):
         priorities = file.read().splitlines()
     return priorities
 
-def prioritize(pvo, two, priorities, count=5):
-    """Given a Pervellam object and a Tw object, make sure our priorities are aligned"""
-    add = []
-    avail = [x['user_login'] for x in two.followed()]
-    for pri in priorities:
-        if pri in avail:
-            add.append(pri)
-            if len(add) == count:
-                break
+def reconcile(pvo, add, count=5, dry_run=False):
+    """Given a Pervellam object and an ordered list of desired live channels
+    (already capped at count), add the missing ones and stop the excess.
+
+    Shared by the priority-file (level 2) and ML (level 3) modes.
+    """
     print("Live:")
     for one in add:
         print(one)
@@ -35,7 +33,8 @@ def prioritize(pvo, two, priorities, count=5):
     print("Add:")
     for job in actual_add:
         print(job)
-        pvo.new_job(config.BASE_URL + job)
+        if not dry_run:
+            pvo.new_job(config.BASE_URL + job)
     total = len(running) + len(actual_add)
     print("Remove:")
     if total > count:
@@ -45,10 +44,34 @@ def prioritize(pvo, two, priorities, count=5):
             if job[1] in add:
                 continue
             print(job[1])
-            pvo.get_job(job[0]).stop()
+            if not dry_run:
+                pvo.get_job(job[0]).stop()
             removed = removed + 1
             if removed == remove:
                 break
+
+def prioritize(pvo, two, priorities, count=5, dry_run=False):
+    """Keep the top `count` live channels from the priority file running"""
+    add = []
+    avail = [x['user_login'] for x in two.followed()]
+    for pri in priorities:
+        if pri in avail:
+            add.append(pri)
+            if len(add) == count:
+                break
+    reconcile(pvo, add, count, dry_run)
+
+def ml_prioritize(pvo, two, count=5, dry_run=False):
+    """Keep the top `count` live channels as ranked by the trained model running"""
+    vectorizer, model = stream_ml.load_model(config.ML_MODEL)
+    scored = [(stream_ml.rank_score(vectorizer, model, stream), stream)
+              for stream in two.followed()]
+    scored.sort(key=lambda pair: pair[0], reverse=True)
+    print("Ranked:")
+    for score, stream in scored:
+        print(stream['user_login'], round(score, 3))
+    add = [stream['user_login'] for score, stream in scored[:count]]
+    reconcile(pvo, add, count, dry_run)
 
 def pri_naieve(pvo, priorities):
     running = [(x["id"], x["url"].split('/')[-1]) for x in pvo.list_jobs()]
@@ -67,34 +90,31 @@ def pri_naieve(pvo, priorities):
 
 
 
-def wrapper(srv, prifile, naieve=False):
+def wrapper(srv, prifile, naieve=False, ml=False, dry_run=False):
     """Setup needed objects and call actual prioritize()"""
-    priorities = read_prifile(prifile)
-    if not naieve:
-        # TODO gotta be a better way
-        two = tw.Tw(url=config.TW_URL,
-                    client_id=config.TW_CLI,
-                    app_access_token=config.TW_APT,
-                    #user_access_token=config.TW_UST,
-                    user_refresh_token=config.TW_URT,
-                    login=config.TW_USR,
-                    id_url=config.TW_IDU,
-                    client_secret=config.TW_CLS)
     pvo = pervellam_client.Pervellam(srv)
     if naieve:
-        pri_naieve(pvo, priorities)
+        pri_naieve(pvo, read_prifile(prifile))
+        return
+    two = tw.Tw.from_config(config)
+    if ml:
+        ml_prioritize(pvo, two, config.MAX, dry_run)
     else:
-        prioritize(pvo, two, priorities, config.MAX)
+        prioritize(pvo, two, read_prifile(prifile), config.MAX, dry_run)
 
 
 def run_cli():
     """Basic CLI"""
     parser = argparse.ArgumentParser(description='Pervellam prioritizer')
     parser.add_argument('server', help='Pervellam server URL')
-    parser.add_argument('prifile', help='Ordered priority file')
+    parser.add_argument('prifile', nargs='?', help='Ordered priority file (not used with --ml)')
     parser.add_argument('-n', '--naieve', action='store_true', help='do not actually check status, just try to add')
+    parser.add_argument('-m', '--ml', action='store_true', help='rank live streams with the trained model instead of a priority file')
+    parser.add_argument('--dry-run', action='store_true', help='print the add/stop plan without changing the server')
     args = parser.parse_args()
-    wrapper(args.server, args.prifile, args.naieve)
+    if not args.ml and not args.prifile:
+        parser.error('prifile is required unless --ml is given')
+    wrapper(args.server, args.prifile, args.naieve, args.ml, args.dry_run)
 
 if __name__ == '__main__':
     run_cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+requests
+fastapi
+sqlalchemy
+# prioritize.py level 3 (ML) + stream_* tooling
+scikit-learn
+nltk
+joblib

--- a/stream_ml.py
+++ b/stream_ml.py
@@ -1,0 +1,85 @@
+"""Shared ML core for guessing stream ratings.
+
+Mirrors the antialgorithm RSS experiment (rssfeaturize.py) but adapted to Twitch
+stream dicts and made reusable: train_save once, then load+rank live streams from
+prioritize.py. Featurization lives here so training and prediction always agree.
+"""
+
+import re
+import joblib
+import numpy as np
+import nltk
+import sklearn.svm
+from sklearn.feature_extraction.text import TfidfVectorizer
+
+STOPWORDS = set(nltk.corpus.stopwords.words('english'))
+
+# Letter grades as a scale, for ranking model predictions (a best, f worst).
+GRADES = {'a': 4, 'b': 3, 'c': 2, 'd': 1, 'f': 0}
+
+
+def tokenize(text):
+    """Lowercase, strip non-letters, drop stopwords (same as the RSS experiment)."""
+    if not text:
+        return ''
+    cleaned = re.sub(r'[^a-z\s]', '', text.lower())
+    return ' '.join(word for word in nltk.tokenize.word_tokenize(cleaned)
+                    if word not in STOPWORDS)
+
+
+def featurize(stream):
+    """Turn a Twitch stream dict into a token blob for TF-IDF.
+
+    Combines the free-text title with the (already categorical) game, channel and
+    language so a single text vectorizer can learn from all of them.
+    """
+    parts = [tokenize(stream.get('title', ''))]
+    for key in ('game_name', 'user_login', 'language'):
+        value = stream.get(key)
+        if value:
+            parts.append(str(value).lower())
+    return ' '.join(part for part in parts if part)
+
+
+def train(scored):
+    """Fit a vectorizer + linear SVM from [{'score', 'data'}] rows.
+
+    Returns (vectorizer, model). A plain SVC is used; rank_score() turns its
+    decision_function into a smooth expected-grade value, so no (fragile on small
+    or imbalanced corpora) probability calibration is needed.
+    """
+    labels = [row['score'] for row in scored]
+    vectorizer = TfidfVectorizer(max_features=262144)
+    features = vectorizer.fit_transform(featurize(row['data']) for row in scored)
+    model = sklearn.svm.SVC(kernel='linear')
+    model.fit(features, labels)
+    return vectorizer, model
+
+
+def save_model(path, vectorizer, model):
+    """Persist the fitted vectorizer and model together."""
+    joblib.dump({'vectorizer': vectorizer, 'model': model}, path)
+
+
+def load_model(path):
+    """Load a (vectorizer, model) pair saved by save_model()."""
+    bundle = joblib.load(path)
+    return bundle['vectorizer'], bundle['model']
+
+
+def rank_score(vectorizer, model, stream):
+    """Expected grade value for a stream, for top-MAX ranking (higher = better).
+
+    Softmaxes the SVM's per-class decision scores into pseudo-probabilities and
+    weights them by the numeric grade scale, so two streams predicted the same
+    letter still order sensibly.
+    """
+    features = vectorizer.transform([featurize(stream)])
+    scores = np.atleast_1d(model.decision_function(features)[0]).astype(float)
+    if len(model.classes_) == 2 and scores.shape == (1,):
+        # Binary SVC returns a single signed score for the second class.
+        scores = np.array([-scores[0], scores[0]])
+    weights = np.exp(scores - scores.max())
+    weights /= weights.sum()
+    return sum(weight * GRADES.get(label, 0)
+               for label, weight in zip(model.classes_, weights))

--- a/stream_score.py
+++ b/stream_score.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+"""Manually rate snapshotted streams (a/b/c/d/f).
+
+Mirrors antialgorithm's manualscore.py: present each not-yet-scored snapshot,
+read a grade, append {hash, score} to ml_data/scores.csv.
+"""
+
+import csv
+import json
+import pathlib
+import random
+
+import config
+import stream_ml
+
+
+def scored_hashes(scorefile):
+    """Return the set of snapshot hashes already present in scorefile."""
+    if not scorefile.exists():
+        return set()
+    with scorefile.open(newline='') as csvfile:
+        return {row['hash'] for row in csv.DictReader(csvfile)}
+
+
+def score(snapdir, scorefile):
+    """Interactively grade unscored snapshots, appending to scorefile."""
+    done = scored_hashes(scorefile)
+    paths = [p for p in snapdir.glob('*.json') if p.stem not in done]
+    random.shuffle(paths)
+    if not paths:
+        print('Nothing left to score.')
+        return
+    for path in paths:
+        stream = json.loads(path.read_text())
+        for key, value in stream.items():
+            print(key, value)
+        grade = ''
+        while grade not in stream_ml.GRADES:
+            grade = input('a/b/c/d/f (or ctrl-c to stop): ').strip().lower()
+        scorefile.parent.mkdir(parents=True, exist_ok=True)
+        write_header = not scorefile.exists()
+        with scorefile.open('a', newline='') as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=['hash', 'score'])
+            if write_header:
+                writer.writeheader()
+            writer.writerow({'hash': path.stem, 'score': grade})
+        print('---')
+
+
+def main():
+    """Score snapshots under config.ML_DATA."""
+    base = pathlib.Path(config.ML_DATA)
+    score(base / 'snapshots', base / 'scores.csv')
+
+
+if __name__ == '__main__':
+    main()

--- a/stream_snap.py
+++ b/stream_snap.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+"""Snapshot available (followed, live) streams as hashed JSON files.
+
+Mirrors antialgorithm's rssparse.py: pull the current pool of streams from the
+site API and dump each as ml_data/snapshots/<hash>.json. Idempotent, so run it
+on a timer to accumulate a corpus to rate and train on.
+"""
+
+import json
+import hashlib
+import pathlib
+
+import tw
+import config
+
+
+def snap(two, snapdir):
+    """Write any not-yet-seen live streams to snapdir; return count written."""
+    snapdir.mkdir(parents=True, exist_ok=True)
+    written = 0
+    for stream in two.followed():
+        outvers = json.dumps(stream, sort_keys=True)
+        outhash = hashlib.sha256(outvers.encode('utf-8')).hexdigest()
+        filename = snapdir / (outhash + '.json')
+        if not filename.exists():
+            filename.write_text(outvers)
+            written += 1
+    return written
+
+
+def main():
+    """Snapshot using config TW_* values into config.ML_DATA/snapshots."""
+    two = tw.Tw.from_config(config)
+    snapdir = pathlib.Path(config.ML_DATA) / 'snapshots'
+    written = snap(two, snapdir)
+    print(f'Wrote {written} new snapshot(s) to {snapdir}')
+
+
+if __name__ == '__main__':
+    main()

--- a/stream_train.py
+++ b/stream_train.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+"""Train the stream-rating model and report accuracy.
+
+Mirrors antialgorithm's rssfeaturize.run_it(): load scored snapshots, do a
+train/test split for a quick accuracy read-out, then retrain on everything and
+save the model for prioritize.py to use.
+"""
+
+import csv
+import json
+import pathlib
+
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import accuracy_score, classification_report
+
+import config
+import stream_ml
+
+
+def load_scored(snapdir, scorefile):
+    """Return [{'hash', 'score', 'data'}] for every scored snapshot."""
+    with scorefile.open(newline='') as csvfile:
+        rows = list(csv.DictReader(csvfile))
+    for row in rows:
+        row['data'] = json.loads((snapdir / (row['hash'] + '.json')).read_text())
+    return rows
+
+
+def report(scored):
+    """Hold-out split, train, and print accuracy + classification report."""
+    train_rows, test_rows = train_test_split(scored, test_size=0.2,
+                                             random_state=42)
+    vectorizer, model = stream_ml.train(train_rows)
+    features = vectorizer.transform(stream_ml.featurize(r['data'])
+                                    for r in test_rows)
+    predicted = model.predict(features)
+    actual = [r['score'] for r in test_rows]
+    print('Accuracy:', accuracy_score(actual, predicted))
+    print('Classification Report:\n', classification_report(actual, predicted,
+                                                            zero_division=0))
+
+
+def main():
+    """Evaluate, then train on all data and save to config.ML_MODEL."""
+    base = pathlib.Path(config.ML_DATA)
+    scored = load_scored(base / 'snapshots', base / 'scores.csv')
+    if not scored:
+        print('No scored snapshots; run stream_score.py first.')
+        return
+    report(scored)
+    vectorizer, model = stream_ml.train(scored)
+    pathlib.Path(config.ML_MODEL).parent.mkdir(parents=True, exist_ok=True)
+    stream_ml.save_model(config.ML_MODEL, vectorizer, model)
+    print('Saved model to', config.ML_MODEL)
+
+
+if __name__ == '__main__':
+    main()

--- a/tw.py
+++ b/tw.py
@@ -15,6 +15,16 @@ class Tw:
         self.user_access_token = None
         self.id_url = id_url
         self.client_secret = client_secret
+    @classmethod
+    def from_config(cls, config):
+        """Build a Tw from a pervellam config module (TW_* values)"""
+        return cls(url=config.TW_URL,
+                   client_id=config.TW_CLI,
+                   app_access_token=config.TW_APT,
+                   user_refresh_token=config.TW_URT,
+                   login=config.TW_USR,
+                   id_url=config.TW_IDU,
+                   client_secret=config.TW_CLS)
     def get(self, url, params, user=False):
         """Make GET request"""
         token = self.app_access_token


### PR DESCRIPTION
Closes #21.

Proposes and implements a way for the system to learn **what to record** from the user's own ratings of available streams, replacing the hand-written priority file as the signal for the autorunner.

## Approach
Adapts the referenced [antialgorithm](https://github.com/ctengel/antialgorithm) RSS experiment (`rssparse` → `manualscore` → `rssfeaturize`) to Twitch streams. `tw.Tw.followed()` already returns the full stream dicts (title, game, viewer count, language, …), so all features are on hand.

Pipeline:
```
./stream_snap.py     # snapshot live followed streams -> ml_data/snapshots/*.json
./stream_score.py    # rate snapshots a/b/c/d/f       -> ml_data/scores.csv
./stream_train.py    # train + accuracy report        -> ml_data/model.joblib
./prioritize.py <server> --ml [--dry-run]  # record the top-MAX model-ranked live streams
```

## What's here
- **`stream_ml.py`** — shared `featurize` / `train` / `save_model` / `load_model` / `rank_score`. Linear `SVC` over TF-IDF of title+game+channel+language; `rank_score` softmaxes the SVM `decision_function` into an expected-grade value (a=4…f=0) for smooth top-MAX ranking — no fragile probability calibration needed on small/imbalanced corpora.
- **`stream_snap.py` / `stream_score.py` / `stream_train.py`** — the three CLIs, mirroring antialgorithm.
- **`prioritize.py`** — new **level 3** (`-m/--ml`): rank live streams by the model, keep top `MAX` running. Extracted `reconcile()` is now shared by level 2 and level 3 (no behavior change). Added `--dry-run` to preview the add/stop plan. `prifile` is optional with `--ml`.
- **`tw.py`** — `Tw.from_config()` factory (reused by snap and level 3; de-dupes the inline construction in `prioritize`).
- Config sample (`ML_DATA`, `ML_MODEL`), `requirements.txt`, README "Level 3 — ML" section, `.gitignore` for `ml_data/`.

## Verification
Ran offline with a fabricated, rated corpus (no creds needed): `stream_train.py` produces an accuracy/classification report and saves the model; `rank_score` orders a coding stream above a "just chatting" one above a slots/gambling one; `prioritize.py --ml --dry-run` (stubbed Tw/Pervellam) prints the ranked add/stop plan without touching the server; levels 1 and 2 verified unchanged after the refactor; CLI requires `prifile` unless `--ml`.

## Notes / follow-ups
- Needs `scikit-learn`, `nltk`, `joblib` plus one-time `nltk.download('stopwords'/'punkt'/'punkt_tab')` (documented in README).
- Snapshot pool is currently *followed live* streams; broadening to discovery/search results is a natural next step toward the milestone's "level 8" (consider what is playing, not just channel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)