### PR TITLE
Fix root cause of orphaned media with an 'upload' status + safe scratch reclaim (#42 #43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,28 @@ between runs):
 OBJIDX_URL=... OBJIDX_AUTH=... ./worker-loop.sh <server> <interval> <worker-id> <datadir> <bucket>
 ```
 
+### Reclaiming scratch space
+
+When a download fails, is stopped, or the worker is killed mid-job, the per-job
+directory under `<datadir>` is left behind — sometimes holding a large media
+file that never made it to ObjectIndex. `cleanup.py` reclaims that space safely:
+
+```
+OBJIDX_URL=... OBJIDX_AUTH=... ./cleanup.py <server> <worker-id> <datadir> <bucket> [--dry-run]
+```
+
+For each of this worker's leftover dirs whose job is in a terminal state
+(`ended`/`stopped`) it either confirms the media is already in OI (the job's
+`fname` is set) or **uploads it to OI first**, and only then deletes the local
+directory. It **never deletes media that isn't in OI**, and never touches dirs
+for active jobs, unknown/missing jobs, or other workers. Use `--dry-run` to see
+what would be reclaimed without changing anything. Run it manually or from cron,
+e.g. hourly:
+
+```
+0 * * * * OBJIDX_URL=... OBJIDX_AUTH=... ~/pervellam/cleanup.py <server> <worker-id> <datadir> <bucket>
+```
+
 ### Keeping yt-dlp up to date
 
 yt-dlp must be kept current — sites change constantly and stable releases are often too old to work.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ OBJIDX_URL=... OBJIDX_AUTH=... ./worker.py <server> <worker-id> <datadir> <bucke
   `<worker-id>-<job-id>-XXXXXX` subdir under it per job
 - `<bucket>` — ObjectIndex bucket to upload into
 
+A job moves through `new → assigned → running → upload → ended`/`stopped`.
+`upload` means the download itself is done but the media is not yet confirmed
+in ObjectIndex — a job only becomes `ended`/`stopped` once its media is safely
+uploaded (its `fname` then holds the OI URL). If the upload fails or the worker
+dies, the job stays visibly in `upload` and its media stays on disk; run
+`cleanup.py` (below) to finish it.
+
 Before claiming a job the worker checks free space in `<datadir>`. If less than
 `WORKER_MIN_FREE_BYTES` (bytes; default 32 GiB) is free it prints a message and
 exits non-zero without claiming — in the loop this just defers to the next run
@@ -96,17 +103,16 @@ file that never made it to ObjectIndex. `cleanup.py` reclaims that space safely:
 OBJIDX_URL=... OBJIDX_AUTH=... ./cleanup.py <server> <worker-id> <datadir> <bucket> [--dry-run]
 ```
 
-For each of this worker's leftover dirs whose job is in a terminal state
-(`ended`/`stopped`) it either confirms the media is already in OI (the job's
-`fname` is set) or **uploads it to OI first**, and only then deletes the local
+For each of this worker's leftover dirs whose job is `ended`/`stopped` or stuck
+in `upload`, it either confirms the media is already in OI (the job's `fname`
+is an OI URL) or **uploads it to OI first**, and only then deletes the local
 directory. It **never deletes media that isn't in OI**, and never touches dirs
-for active jobs, unknown/missing jobs, or other workers. Use `--dry-run` to see
-what would be reclaimed without changing anything. Run it manually or from cron,
-e.g. hourly:
+for downloading jobs, unknown/missing jobs, or other workers. Use `--dry-run`
+to see what would be reclaimed without changing anything.
 
-```
-0 * * * * OBJIDX_URL=... OBJIDX_AUTH=... ~/pervellam/cleanup.py <server> <worker-id> <datadir> <bucket>
-```
+Run it while the worker is idle: a job the worker is *currently* uploading is
+also in `upload` status, and sweeping it concurrently could upload a duplicate
+to OI.
 
 ### Keeping yt-dlp up to date
 

--- a/cleanup.py
+++ b/cleanup.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+
+"""Reclaim leftover worker scratch directories, preserving media in OI first.
+
+For each per-job directory left under datadir, this finds the matching Pervellam
+job and only removes the directory once we are certain its media is safe in
+ObjectIndex (OI): either the job's ``fname`` already points at OI, or we upload
+the media ourselves first. Active jobs, unknown/missing jobs, and directories we
+cannot upload are left untouched.
+"""
+
+import argparse
+import os
+import pathlib
+import shutil
+import warnings
+
+import pervellam_client
+import worker
+
+TERMINAL_STATUSES = ('ended', 'stopped')
+
+
+def parse_job_id(dirname, dler):
+    """Return the job id encoded in a worker scratch dir name, or None.
+
+    Dir names are ``f"{dler}-{job_id}-{random}"`` (see worker.cdul_wrapper).
+    """
+    prefix = f"{dler}-"
+    if not dirname.startswith(prefix):
+        return None
+    head = dirname[len(prefix):].split('-', 1)[0]
+    return int(head) if head.isdigit() else None
+
+
+def dir_size(path):
+    """Total size in bytes of everything under path."""
+    return sum(f.stat().st_size for f in path.rglob('*') if f.is_file())
+
+
+def fetch_job(myp, job_id):
+    """Return (job, info) for job_id, or (None, None) if it is gone/unreachable."""
+    job = myp.get_job(job_id)
+    try:
+        return job, job.get()
+    except pervellam_client.requests.exceptions.HTTPError as exc:
+        if exc.response is not None and exc.response.status_code == 404:
+            return None, None
+        warnings.warn(f'Cannot reach server for job {job_id}: {exc}')
+        return None, None
+    except pervellam_client.requests.exceptions.RequestException as exc:
+        warnings.warn(f'Cannot reach server for job {job_id}: {exc}')
+        return None, None
+
+
+def sweep_dir(path, dler, bucket, myp, dry_run):
+    """Decide and (unless dry_run) act on one scratch dir. Return bytes reclaimed."""
+    job_id = parse_job_id(path.name, dler)
+    if job_id is None:
+        return 0  # not one of our scratch dirs
+    size = dir_size(path)
+    job, info = fetch_job(myp, job_id)
+    if info is None:
+        warnings.warn(f'{path.name}: no job {job_id} on server — manual review, keeping')
+        return 0
+    if info.get('status') not in TERMINAL_STATUSES:
+        print(f'{path.name}: job {job_id} is {info.get("status")} (active) — keeping')
+        return 0
+    if info.get('fname'):
+        if dry_run:
+            print(f'{path.name}: in OI already — would delete ({size} bytes)')
+        else:
+            shutil.rmtree(path)
+            print(f'{path.name}: in OI already — deleted ({size} bytes)')
+        return size
+    # Terminal job, not yet in OI: upload first, then delete.
+    if dry_run:
+        print(f'{path.name}: job {job_id} not in OI — would upload then delete ({size} bytes)')
+        return size
+    cwd = os.getcwd()
+    try:
+        os.chdir(path)
+        worker.upload_dir(path, bucket, job)
+    except Exception as exc:  # noqa: BLE001 - any failure must NOT delete
+        os.chdir(cwd)
+        warnings.warn(f'{path.name}: could not upload job {job_id} to OI ({exc}) — keeping')
+        return 0
+    os.chdir(cwd)
+    shutil.rmtree(path)
+    print(f'{path.name}: uploaded to OI then deleted ({size} bytes)')
+    return size
+
+
+def cleanup(server, dler, datadir, bucket, dry_run=False):
+    """Sweep every scratch dir under datadir."""
+    myp = pervellam_client.Pervellam(server, dler)
+    total = 0
+    for path in sorted(pathlib.Path(datadir).iterdir()):
+        if path.is_dir():
+            total += sweep_dir(path, dler, bucket, myp, dry_run)
+    verb = 'would reclaim' if dry_run else 'reclaimed'
+    print(f'{verb} {total} bytes')
+
+
+def run_cli():
+    """Basic CLI"""
+    parser = argparse.ArgumentParser(description='Pervellam scratch-space cleanup')
+    parser.add_argument('server', help='Pervellam server URL')
+    parser.add_argument('dler', help='Name of the worker whose dirs to sweep')
+    parser.add_argument('datadir')
+    parser.add_argument('bucket', help='ObjectIndex bucket to upload pending media into')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Report what would happen without changing anything')
+    args = parser.parse_args()
+    cleanup(args.server, args.dler, args.datadir, args.bucket, args.dry_run)
+
+
+if __name__ == '__main__':
+    run_cli()

--- a/cleanup.py
+++ b/cleanup.py
@@ -4,9 +4,14 @@
 
 For each per-job directory left under datadir, this finds the matching Pervellam
 job and only removes the directory once we are certain its media is safe in
-ObjectIndex (OI): either the job's ``fname`` already points at OI, or we upload
-the media ourselves first. Active jobs, unknown/missing jobs, and directories we
-cannot upload are left untouched.
+ObjectIndex (OI): either the job's ``fname`` already points at OI (an http URL —
+a bare filename there is just a progress snapshot and proves nothing), or we
+upload the media ourselves first. Active jobs, unknown/missing jobs, and
+directories we cannot upload are left untouched.
+
+Jobs stuck in 'upload' status (download done, upload to OI interrupted) are
+finished here too. Since a job the worker is *currently* uploading has that same
+status, run this while the worker is idle to avoid a duplicate upload.
 """
 
 import argparse
@@ -19,6 +24,8 @@ import pervellam_client
 import worker
 
 TERMINAL_STATUSES = ('ended', 'stopped')
+# 'upload' = download finished but the OI upload was interrupted (see worker.py)
+SWEEPABLE_STATUSES = TERMINAL_STATUSES + ('upload',)
 
 
 def parse_job_id(dirname, dler):
@@ -63,24 +70,29 @@ def sweep_dir(path, dler, bucket, myp, dry_run):
     if info is None:
         warnings.warn(f'{path.name}: no job {job_id} on server — manual review, keeping')
         return 0
-    if info.get('status') not in TERMINAL_STATUSES:
-        print(f'{path.name}: job {job_id} is {info.get("status")} (active) — keeping')
+    status = info.get('status')
+    if status not in SWEEPABLE_STATUSES:
+        print(f'{path.name}: job {job_id} is {status} (active) — keeping')
         return 0
-    if info.get('fname'):
+    # Only an fname holding an OI URL proves the media is in OI: while
+    # downloading, the worker PATCHes the bare local filename into fname.
+    if str(info.get('fname') or '').startswith('http'):
         if dry_run:
             print(f'{path.name}: in OI already — would delete ({size} bytes)')
         else:
             shutil.rmtree(path)
             print(f'{path.name}: in OI already — deleted ({size} bytes)')
         return size
-    # Terminal job, not yet in OI: upload first, then delete.
+    # Swept job whose media never reached OI: upload first, then delete.
     if dry_run:
         print(f'{path.name}: job {job_id} not in OI — would upload then delete ({size} bytes)')
         return size
+    # for a stuck 'upload' the ended-vs-stopped distinction is long gone; use 'ended'
+    final_status = status if status in TERMINAL_STATUSES else 'ended'
     cwd = os.getcwd()
     try:
         os.chdir(path)
-        worker.upload_dir(path, bucket, job)
+        worker.upload_dir(path, bucket, job, final_status)
     except Exception as exc:  # noqa: BLE001 - any failure must NOT delete
         os.chdir(cwd)
         warnings.warn(f'{path.name}: could not upload job {job_id} to OI ({exc}) — keeping')

--- a/server.py
+++ b/server.py
@@ -89,9 +89,11 @@ def joblist(filt: str = None, db: Session = Depends(get_db)) -> list[Job]:
     if filt == 'active':
         return db.query(JobTable).filter(~JobTable.status.in_(['ended', 'stopped'])).all()
     if filt == 'finished':
+        # fname is only an OI link once the upload finished (an http URL);
+        # earlier it holds the bare local filename, useless to link to (#42)
         return (db.query(JobTable)
                 .filter(JobTable.status.in_(['ended', 'stopped']))
-                .filter(JobTable.fname.isnot(None))
+                .filter(JobTable.fname.like('http%'))
                 .order_by(JobTable.updated.desc())
                 .limit(20)
                 .all())

--- a/worker.py
+++ b/worker.py
@@ -142,6 +142,26 @@ def run_one(dler, myj):
             continue
 
 
+def upload_dir(newpath, bucket, myj):
+    """Upload the media in newpath to OI and record its OI URL on the job.
+
+    Returns the local media_file Path (caller deletes it). Raises if there is no
+    info-json / media to upload, so callers can decline to delete on failure.
+    """
+    info_json = None
+    for pij in newpath.iterdir():
+        if tuple(pij.suffixes) == ('.info', '.json'):
+            info_json = pij
+    assert info_json
+    info_json_data = dlpmeta.DLPMetaData(from_file=info_json, partial=True)
+    media_file = info_json_data.get_media_file()
+    assert media_file != info_json
+    info_json_data.add_lpm(LPM_LIB)
+    oi_file = info_json_data.upload(oiclient.get_obj_idx_env(), bucket)
+    myj.update({'fname': oi_file.oio.url + 'file/' + str(oi_file.uuid)})
+    return media_file
+
+
 def cdul_wrapper(server, dler, datadir, bucket):
     """Put in a specific directory and upload to OI"""
     check_free_space(datadir)
@@ -160,19 +180,8 @@ def cdul_wrapper(server, dler, datadir, bucket):
         warnings.warn('no file to upload')
         os.chdir(cwd)
         return
-    info_json = None
-    for pij in newpath.iterdir():
-        if tuple(pij.suffixes) == ('.info', '.json'):
-            info_json = pij
-    assert info_json
-    assert info_json.name != file_info['fname']
-    info_json_data = dlpmeta.DLPMetaData(from_file=info_json, partial=True)
-    media_file = info_json_data.get_media_file()
-    assert media_file != info_json
+    media_file = upload_dir(newpath, bucket, myj)
     assert media_file.name == file_info['fname']
-    info_json_data.add_lpm(LPM_LIB)
-    oi_file = info_json_data.upload(oiclient.get_obj_idx_env(), bucket)
-    myj.update({'fname': oi_file.oio.url + 'file/' + str(oi_file.uuid)})
     media_file.unlink()
     os.chdir(cwd)
 

--- a/worker.py
+++ b/worker.py
@@ -89,76 +89,102 @@ class DLPJob:
                                                            datetime.timezone.utc).isoformat()}
 
 
+def report_downloaded(myj, file_info, final_status):
+    """Record that downloading is done: 'upload' status until media is in OI.
+
+    A job only becomes 'ended'/'stopped' once its media is safely in OI (or
+    there is nothing to upload), so an interrupted upload stays visible as
+    'upload' instead of silently stranding the media (#42/#43).
+    """
+    file_info['status'] = 'upload' if file_info['fname'] else final_status
+    myj.update(file_info, retry=True)
+    return file_info, final_status
+
+
 def run_one(dler, myj):
-    """Check for a new job, assign, run, wait to finish or stop"""
+    """Check for a new job, assign, run, wait to finish or stop
+
+    Returns (file_info, final_status): the last snapshot of the downloaded
+    file and the terminal status ('ended'/'stopped') to record once the media
+    is safely in OI.
+    """
     print(f'Assigned job {myj.job_id}; getting more details...')
     job_info = myj.get(retry=True)
     assert job_info["dler"] == dler
     myd = DLPJob(job_info["url"])
-    print('Job commenced, doing initial update...')
-    job_info = myj.update({'started': datetime.datetime.now(datetime.timezone.utc).isoformat(),
-                           'updated': datetime.datetime.now(datetime.timezone.utc).isoformat(),
-                           'status': 'running'},
-                          retry=True)
-    print('Looping and waiting...')
-    while True:
-        if job_info["dler"] != dler:
-            warnings.warn('Conflict dectected, self destructing...')
-            myd.stop()
-            # TODO throw a better exception here
-            assert False
-        time.sleep(60)
-        try:
-            pjs = myj.get()["status"]
-        except pervellam_client.requests.exceptions.RequestException:
-            # NOTE this does not use the myj.update(retry=True) logic as below
-            #      because since this download is still healthy better to stay in normal loop
-            warnings.warn('Cannot get status from Pervellam server, will retry in a minute...')
-            continue
-        # 'stopped' here means a force-stop already flipped the status (issue #39);
-        # treat it like a stopreq so the still-running download is actually killed.
-        if pjs in ("stopreq", "stopped"):
-            print('Recieved stop request...')
-            myd.stop()
-            print('Job stopped!')
+    try:
+        print('Job commenced, doing initial update...')
+        job_info = myj.update({'started': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                               'updated': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                               'status': 'running'},
+                              retry=True)
+        print('Looping and waiting...')
+        while True:
+            if job_info["dler"] != dler:
+                warnings.warn('Conflict dectected, self destructing...')
+                # TODO throw a better exception here
+                assert False
+            time.sleep(60)
+            try:
+                pjs = myj.get()["status"]
+            except pervellam_client.requests.exceptions.RequestException:
+                # NOTE this does not use the myj.update(retry=True) logic as below
+                #      because since this download is still healthy better to stay in normal loop
+                warnings.warn('Cannot get status from Pervellam server, will retry in a minute...')
+                continue
+            # 'stopped' here means a force-stop already flipped the status (issue #39);
+            # treat it like a stopreq so the still-running download is actually killed.
+            if pjs in ("stopreq", "stopped"):
+                print('Recieved stop request...')
+                myd.stop()
+                print('Job stopped!')
+                return report_downloaded(myj, myd.file_info(), 'stopped')
             file_info = myd.file_info()
-            file_info['status'] = 'stopped'
-            myj.update(file_info, retry=True)
-            return file_info
-        file_info = myd.file_info()
-        if not myd.status():
-            print('Job stopped organically!')
-            myd.close()
-            # TODO indicate 'failed' if nonzero or file missing etc
-            file_info['status'] = 'ended'
-            myj.update(file_info, retry=True)
-            return file_info
-        try:
-            job_info = myj.update(file_info)
-        except pervellam_client.requests.exceptions.RequestException:
-            # NOTE this does not use the myj.update(retry=True) logic as above
-            #      because since this download is still healthy better to stay in normal loop
-            warnings.warn('Cannot update Pervellam server, will retry in a minute...')
-            continue
+            if not myd.status():
+                print('Job stopped organically!')
+                myd.close()
+                # TODO indicate 'failed' if nonzero or file missing etc
+                return report_downloaded(myj, file_info, 'ended')
+            try:
+                job_info = myj.update(file_info)
+            except pervellam_client.requests.exceptions.RequestException:
+                # NOTE this does not use the myj.update(retry=True) logic as above
+                #      because since this download is still healthy better to stay in normal loop
+                warnings.warn('Cannot update Pervellam server, will retry in a minute...')
+                continue
+    finally:
+        # never leave yt-dlp downloading detached if we bail out for any reason
+        if myd.status():
+            myd.stop()
 
 
-def upload_dir(newpath, bucket, myj):
-    """Upload the media in newpath to OI and record its OI URL on the job.
+def upload_dir(newpath, bucket, myj, final_status, expect_fname=None):
+    """Upload the media in newpath to OI, then record its OI URL and
+    final_status on the job in a single update.
 
-    Returns the local media_file Path (caller deletes it). Raises if there is no
-    info-json / media to upload, so callers can decline to delete on failure.
+    Returns the local media_file Path (caller deletes it). Raises if there is
+    no info-json / media to upload (or the media is not the expect_fname the
+    download reported), so callers can decline to delete on failure; the job
+    then stays in 'upload' status rather than looking done.
     """
     info_json = None
     for pij in newpath.iterdir():
         if tuple(pij.suffixes) == ('.info', '.json'):
             info_json = pij
-    assert info_json
+    if not info_json:
+        raise RuntimeError(f'no info-json in {newpath}')
     info_json_data = dlpmeta.DLPMetaData(from_file=info_json, partial=True)
     media_file = info_json_data.get_media_file()
-    assert media_file != info_json
+    if media_file == info_json:
+        raise RuntimeError(f'no media besides info-json {info_json} in {newpath}')
+    if expect_fname and media_file.name != expect_fname:
+        raise RuntimeError(f'info-json names media {media_file.name} '
+                           f'but download reported {expect_fname}')
     info_json_data.add_lpm(LPM_LIB)
     oi_file = info_json_data.upload(oiclient.get_obj_idx_env(), bucket)
-    myj.update({'fname': oi_file.oio.url + 'file/' + str(oi_file.uuid)})
+    myj.update({'fname': oi_file.oio.url + 'file/' + str(oi_file.uuid),
+                'status': final_status},
+               retry=True)
     return media_file
 
 
@@ -175,15 +201,21 @@ def cdul_wrapper(server, dler, datadir, bucket):
     newpath = pathlib.Path(tempfile.mkdtemp(prefix=f"{dler}-{myj.job_id}-",
                                             dir=datadir))
     os.chdir(newpath)
-    file_info = run_one(dler, myj)
-    if not file_info['fname']:
-        warnings.warn('no file to upload')
+    try:
+        file_info, final_status = run_one(dler, myj)
+        if not file_info['fname']:
+            warnings.warn('no file to upload')
+            return
+        try:
+            media_file = upload_dir(newpath, bucket, myj, final_status,
+                                    expect_fname=file_info['fname'])
+        except Exception as exc:  # noqa: BLE001 - keep media, stay in 'upload'
+            warnings.warn(f'could not upload job {myj.job_id} to OI ({exc}); '
+                          'media kept on disk, job left in upload status for cleanup.py')
+            sys.exit(1)
+        media_file.unlink()
+    finally:
         os.chdir(cwd)
-        return
-    media_file = upload_dir(newpath, bucket, myj)
-    assert media_file.name == file_info['fname']
-    media_file.unlink()
-    os.chdir(cwd)
 
 def run_cli():
     """Basic CLI"""


### PR DESCRIPTION
## What

Two commits:

1. **cleanup.py** — a standalone tool that reclaims orphaned worker scratch
   directories without ever risking data loss (upload-to-OI-first, then delete).
2. **Root-cause fix (#42 #43)** — a new `upload` job status so a job is never
   marked terminal before its media is confirmed in ObjectIndex, plus a fix for
   a data-loss bug in commit 1.

## Root cause of orphaned media

The worker marked a job `ended`/`stopped` *before* uploading to OI, and the only
deletion of local media (`media_file.unlink()`) came after a successful upload +
fname PATCH. Any failure in that window stranded the MP4 silently while the job
looked done:

- OI upload raising (OI down, network) — job already terminal, never retried
- the fname PATCH after upload had no retry — one transient error lost the OI URL
- worker/host death during the (long) upload
- bare asserts on info-json/media-name mismatch killing the worker pre-upload
- exceptions in the polling loop leaving yt-dlp downloading detached

Issue #42's jobs that "for a long time just have the filename (not OI)" are this:
`fname` holds a bare local basename (the worker PATCHes it as a progress
snapshot every minute), so **fname being set never proved the media was in OI** —
only an `http…` OI URL does.

## The fix

- Job lifecycle is now `new → assigned → running → upload → ended/stopped`.
  `upload` = download done, media not yet confirmed in OI. The terminal status
  and the OI-URL fname land in a single retried PATCH after a successful upload.
- Upload failures warn and exit non-zero, leaving the job **visibly** in
  `upload` and the media on disk; cleanup.py finishes it later (run it while the
  worker is idle to avoid duplicating an in-flight upload).
- `run_one()` stops yt-dlp in a `finally` so exceptions can't leave it running
  detached.
- cleanup.py now treats only an `http` fname as proof-of-OI (its original
  "fname set ⇒ in OI" assumption would have **deleted media that was never
  uploaded**), and also sweeps jobs stuck in `upload`, finishing them as `ended`.
- The server's `finished` filter requires an `http` fname, so legacy stranded
  jobs stop showing broken "Open in OI" links (#42).

No schema change: `upload` fits the existing `String(8)` status column.

## Testing

Verified end-to-end against a live server with a stub yt-dlp and stub OI:
happy path (`running → upload → ended` + OI URL, media unlinked); OI-down
(job stays `upload`, media kept, exit 1); stop request (`→ stopped` + OI URL);
dler conflict (yt-dlp child killed, no detached download); `finished` filter
excludes basename fnames; cleanup dry-run/real run: in-OI dirs deleted,
stuck-`upload` and legacy basename-fname jobs uploaded-then-deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)